### PR TITLE
Support multiple context

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -2,9 +2,9 @@
 Changelog
 =========
 
-* Support multiple context in ``Signposting``
-* RFC7231 update: Don't resolve context according to ``Content-Location``
-* Linkset parsing exposed as ``find_signposting_linkset``
+* Support multiple context in ``Signposting`` -- users of ``find_signposting_linkset`` should take particularly care to look up using ``for_context``
+* RFC7231 update: Don't resolve context according to ``Content-Location`` header
+* Linkset parsing exposed as ``find_signposting_linkset`` in ``signposting`` module
 * Optional explicit content-negotiate for linksets
 * Integration tests for linksets using a2a-fair-metrics benchmarks
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* Support multiple context in ``Signposting``
+* RFC7231 update: Don't resolve context according to ``Content-Location``
 * Linkset parsing exposed as ``find_signposting_linkset``
 * Optional explicit content-negotiate for linksets
 * Integration tests for linksets using a2a-fair-metrics benchmarks

--- a/src/signposting/htmllinks.py
+++ b/src/signposting/htmllinks.py
@@ -51,7 +51,7 @@ class DownloadedText(str):
     """The requested URL, before redirection"""
 
     resolved_url: AbsoluteURI
-    """The resolved URL, after redirection and observing any Content-Location header."""
+    """The resolved URL, after redirection."""
 
     def __new__(cls, value:str, content_type:str, requested_url:AbsoluteURI, resolved_url:AbsoluteURI):
         # NOTE: Do not return value if it's already an DownloadedText
@@ -87,9 +87,14 @@ def _get_html(uri:AbsoluteURI) -> Union[HTML,XHTML]:
     page = requests.get(uri, headers=HEADERS)
 
     resolved_url = AbsoluteURI(page.url, uri)
-    if "Content-Location" in page.headers:
-        # More specific, e.g. "index.en.html" - parse as relative URI reference
-        resolved_url = AbsoluteURI(page.headers["Content-Location"], resolved_url)
+    
+    # Note: According to HTTP/1.1 updates (Appendix B) in 
+    # https://datatracker.ietf.org/doc/html/rfc7231
+    # then Content-Location should NO LONGER be used for 
+    # resolving relative URI references.
+    ##if "Content-Location" in page.headers:
+    ##    # More specific, e.g. "index.en.html" - parse as relative URI reference
+    ##    resolved_url = AbsoluteURI(page.headers["Content-Location"], resolved_url)
 
     if page.status_code == 203:
         warnings.warn("203 Non-Authoritative Information <%s> - Signposting URIs may have been rewritten by proxy" %

--- a/src/signposting/linkset.py
+++ b/src/signposting/linkset.py
@@ -73,9 +73,14 @@ def _get_linkset(uri:AbsoluteURI, acceptType:MediaType=None) -> Union[LinksetJSO
     page = requests.get(uri, headers=header)
 
     resolved_url = AbsoluteURI(page.url, uri)
-    if "Content-Location" in page.headers:
-        # More specific, e.g. "index.en.html" - parse as relative URI reference
-        resolved_url = AbsoluteURI(page.headers["Content-Location"], resolved_url)
+
+    # Note: According to HTTP/1.1 updates (Appendix B) in 
+    # https://datatracker.ietf.org/doc/html/rfc7231
+    # then Content-Location should NO LONGER be used for 
+    # resolving relative URI references.
+    ##if "Content-Location" in page.headers:
+    ##    # More specific, e.g. "index.en.html" - parse as relative URI reference
+    ##    resolved_url = AbsoluteURI(page.headers["Content-Location"], resolved_url)
 
     if page.status_code == 203:
         warnings.warn("203 Non-Authoritative Information <%s> - Signposting URIs may have been rewritten by proxy" %

--- a/src/signposting/signpost.py
+++ b/src/signposting/signpost.py
@@ -187,7 +187,8 @@ SIGNPOSTING = set(l.value for l in LinkRel)
 class Signpost:
     """An individual link of Signposting, e.g. for ``rel=cite-as``.
 
-    This is a convenience class that may be wrapping a :attr:`link`. 
+    This is a convenience class that may be wrapping a :attr:`link`
+    or otherwise constructed.
 
     In some case the link relation may have additional attributes,
     e.g. ``signpost.link["title"]`` - the purpose of this class is however to
@@ -200,10 +201,9 @@ class Signpost:
     target: AbsoluteURI
     """The URI that is the target of this link, e.g. ``http://example.com/``
     
-    Note that URIs with Unicode characters will be represented as %-escaped URIs.
+    Note that URIs with Unicode characters will be represented as %-escaped URIs rather than as IRIs.
     """
 
-    # TODO: Check RFC if this may also be a URI.
     type: Optional[MediaType]
     """The media type of the target.
 
@@ -224,16 +224,22 @@ class Signpost:
     For instance, a ``rel=describedby`` signpost to a JSON-LD document can have
     ``type=application/ld+json`` and ``profile=http://www.w3.org/ns/json-ld#compacted``
 
-    As there may be multiple profiles, or (more commonly) none,
-    this property is typed as a :class:`FrozenSet`.
+    There may be multiple profiles, or (more commonly) none.
     """
 
     context: Optional[AbsoluteURI]
     """Resource URL this is the signposting for, e.g. a HTML landing page.
+
+    Note that following HTTP redirections and ``Content-Location`` headers
+    means this URI
+
+    This attribute is optional (with ``None`` indicating unknown context),
+    however producers of ``Signpost`` instances from are encouraged to 
+
     """
 
     link: Optional[Link]
-    """The Link this signpost came from.
+    """The Link object this signpost was created from.
 
     May contain additional attributes such as ``link["title"]``.
     Note that a single Link may have multiple ``rel``s, therefore it is
@@ -290,6 +296,8 @@ class Signpost:
             self.context = context
         elif context:
             self.context = AbsoluteURI(context)  # may throw ValueError
+        else:
+            self.context = None
 
         self.link = link
 
@@ -335,21 +343,31 @@ class Signposting(Iterable[Signpost], Sized):
     """
 
     context_url: Optional[AbsoluteURI]
-    """Resource URL this is the signposting for, e.g. a HTML landing page.
+    """Resource URI this is the signposting for, e.g. a HTML landing page, hereafter called "this resource".
+    
+    This attribute is optional, `None` indicate
+    no context filtering applies and that
+    individual signposts can have any context.
+    """
+
+    other_contexts: Set[AbsoluteURI]
+    """Other resource URLs which signposting has been provided for. 
+    
+    Use :meth:`for_context` to retrieve their signpostings, or filter the full list of signposts from :prop:`signposts` according to :attr:`Signpost.context`
     """
 
     authors: Set[Signpost]
-    """Author(s) of the resource (and possibly its items)"""
+    """Author(s) of this resource (and possibly its items)"""
 
     describedBy: Set[Signpost]
-    """Metadata resources about the resource and its items, typically in a Linked Data format.
+    """Metadata resources about this resource and its items, typically in a Linked Data format.
 
     Resources may require content negotiation, check `Signpost.type` attribute
     (if present) for content type, e.g. ``text/turtle``.
     """
 
     types: Set[Signpost]
-    """Semantic types of the resource, e.g. from schema.org"""
+    """Semantic types of this resource, e.g. from schema.org"""
 
     items: Set[Signpost]
     """Items contained by this resource, e.g. downloads.
@@ -358,7 +376,7 @@ class Signposting(Iterable[Signpost], Sized):
     """
 
     linksets: Set[Signpost]
-    """Linkset resuorces with further signposting.
+    """Linkset resources with further signposting for this resource (and potentially others).
 
     A `linkset`_ is a JSON or text serialization of Link headers available as a
     separate resource, and may be used to externalize large collection of links, e.g.
@@ -377,23 +395,40 @@ class Signposting(Iterable[Signpost], Sized):
     """Optional license of this resource (and presumably its items)"""
 
     collection: Optional[Signpost]
-    """Optional collection this resource is part of"""
-
-    def __init__(self, context_url: Union[AbsoluteURI, str] = None, signposts: Iterable[Signpost] = None):
+    """Optional collection resource that the selected resource is part of"""
+    
+    def __init__(self, 
+                 context_url: Union[AbsoluteURI, str] = None, 
+                 signposts: Iterable[Signpost] = None,
+                 include_no_context: bool = True):
         """Construct a Signposting from a list of :class:`Signpost`s.
 
-        :param context_url: the resource to select signposting for, or any signposts if ``None``.
-        :param signposts: The list of :class:`Signpost`s that should be considered for selecting signposting.
-            Signposts are assigned to attributes like :attr:`citeAs` or :attr:`describedBy`
-            depending on their :attr:`Signpost.rel` link relation.
-            Any signposts with a non-empty :attr:`Signpost.context` that does 
-            not match ``context_url`` (if provided) will not be assigned,
-            but still remain part of this signposting object as an iterable object.
+        Signposts are filtered by the matching `context_url` (if provided), 
+        then assigned to attributes like :attr:`citeAs` or :attr:`describedBy`
+        depending on their :attr:`Signpost.rel` link relation.
+
+        Multiple signposts discovered for singular relations like ``citeAs`` 
+        are ignored in this attribute assignment, however these are included in
+        the `Iterable` interface of this class and thus also in its length.
+
+        A Signposting object is equivalent to boolean `False` in conditional expression 
+        if it is empty, that is ``len(signposting)==0``, indicating no signposts 
+        were discovered for the given context. However the remaining 
+        ``signposts`` will still be available from :attr:`signposts`, as
+        indicated by :attr:`other_contexts`.
+        
+        :param context_url: the resource to select signposting for, or any signposts if ``None``.            
+        :param signposts: An iterable of :class:`Signpost`s that should be considered for selecting signposting.
+        :param include_no_context: If true (default), consider signposts without explicit context, 
+            assuming they are about ``context_url``. 
+            If false, such signposts are ignored for assignment, 
+            but remain available from :attr:`signposts`.
+        :raise ValueError: If ``include_no_context`` is false, but ``context_url`` was not provided or None.
         """
         if context_url:
             self.context_url = AbsoluteURI(context_url)
         else:
-            self.context_url = None
+            self.context_url = None # No filtering
 
         # Initialize attributes with empty defaults
         self.citeAs = None
@@ -404,19 +439,19 @@ class Signposting(Iterable[Signpost], Sized):
         self.items = set()
         self.linksets = set()
         self.types = set()
-        self._extras = set() # Any extra signposts, ideally none
+        self.other_contexts = set()
+        self._extras = set() # Any extra signposts, ideally empty
+        self._others = set() # Signposts with a different context
 
         if signposts is None:
-            return
-        # Populate from list of signposts
+            return # We're empty
+        # Populate above attributes from list of signposts
         for s in signposts:
-            # TODO: Replace with match..case requires Python 3.10+ (PEP 634)
-            # match s.rel:
-            #    case LinkRel.cite_as:
-            #        self.citeAs = s
-            #    case LinkRel.license:
-            # ...
-            if s.rel is LinkRel.cite_as:
+            if self.context_url and self.context_url != s.context:
+                self._others.add(s)
+                if s.context:
+                    self.other_contexts.add(s.context)
+            elif s.rel is LinkRel.cite_as:
                 if self.citeAs:
                     warnings.warn("Ignoring additional cite-as signposts")
                     self._extras.add(s)
@@ -451,44 +486,43 @@ class Signposting(Iterable[Signpost], Sized):
 
     @property
     def signposts(self) -> AbstractSet[Signpost]:
-        """All FAIR Signposts for recognized relation types.
+        """All FAIR Signposts with recognized relation types.
         
         This may include any additional signposts for link relations
-        that only expect a single link, like :prop:`citeAs`.
+        that only expect a single link, like :prop:`citeAs`, as well
+        as any signposts for other contexts as listed in :prop:`other_contexts`.
 
-        It is also possible to iterate directly over this class, see
-        :meth:`__iter__`
+        For only the signposts that match the given context, use 
+        :meth:`__iter__`, e.g. ``for s in signposting`` or ``matched = set(signposts)``
         """
-        return frozenset(self)
+        return frozenset(itertools.chain(self, self._others))
 
-    @property
-    def contexts(self) -> AbstractSet[AbsoluteURI]:
-        """All contexts covered by this Signposting collection"""
-        contexts = {s.context for s in self if s.context}
-        if self.context_url:
-            contexts.add(self.context_url)
-        return frozenset(contexts)
-
-    def for_context(self, context_uri:Union[AbsoluteURI, str]):
+    def for_context(self, context_uri:Union[AbsoluteURI, str, None]):
         """Return signposting for given context URI.
         
-        This will select an alternative view of the signposts in this collection.         
+        This will select an alternative view of the signposts from :attr:`signposts`
+        filtered by the given ``context_uri``.
 
-        :param context_uri: The context to select signposts from. The URI should be a
-            member of :attr:`contexts`.
+        :param context_uri: The context to select signposts from. 
+            The URI should be a member of :attr:`contexts` or equal to :attr:`context`, 
+            otherwise the returned Signposting will be empty.
+            If the context_uri is `None`, then the :attr:`Signpost.context` is ignored
+            and any signposts will be considered.
         """
         if self.context_url == context_uri:
-            return self        
-        return Signposting(context_uri, self)
+            return self
+        # Chain in own signposts, in case they want to call for_context() 
+        # back to our context. 
+        return Signposting(context_uri, itertools.chain(self, self._others), include_no_context=False)
 
     def __len__(self):
-        """Count how many FAIR Signposts were recognized"""
+        """Count how many FAIR Signposts were recognized for the given context"""
         return len(self.signposts)
     
     def __iter__(self) -> Iterator[Signpost]:
-        """Iterate over all recognized FAIR signposts.
+        """Iterate over all FAIR signposts recognized for the given context.
 
-        See also the property :prop:`signposts`
+        See also the property :prop:`signposts` for signposts of any context.
         """
         if self.citeAs:
             yield self.citeAs
@@ -506,6 +540,7 @@ class Signposting(Iterable[Signpost], Sized):
             yield t
         for e in self._extras:
             yield e
+        # NOTE: self._others are NOT included as they have a different context
 
     def _repr_signposts(self, signposts):
         return " ".join(set(d.target for d in signposts))
@@ -530,6 +565,8 @@ class Signposting(Iterable[Signpost], Sized):
             repr.append("linksets=%s" % self._repr_signposts(self.linksets))
         if self.types:
             repr.append("types=%s" % self._repr_signposts(self.types))
+        if self.other_contexts:
+            repr.append("other_contexts=%s" % " ".join(self.other_contexts))
 
         return "<Signposting %s>" % "\n ".join(repr)
 
@@ -537,7 +574,7 @@ class Signposting(Iterable[Signpost], Sized):
         """Represent signposts as HTTP Link headers.
         
         Note that these are reconstructed from the recognized link relations only,
-        and do not include unparsed additional link attributes.
+        and do not include unparsed additional link attributes or links with different contexts.
 
         See also `Signpost.link`
         """

--- a/tests/test_htmllinks.py
+++ b/tests/test_htmllinks.py
@@ -155,7 +155,7 @@ class TestGetHTML(unittest.TestCase):
             self.assertIn("xmlns=", html)
             self.assertEqual("application/xml+xhtml", html.content_type)
             self.assertEqual("https://example.com/TODO-xhtml/", html.requested_url)
-            self.assertEqual("https://example.com/TODO-xhtml/index.xhtml", html.resolved_url)
+            self.assertEqual("https://example.com/TODO-xhtml/", html.resolved_url)
 
     def test_get_html_resolved_relative(self):
         with requests_mock.Mocker() as m:

--- a/tests/test_htmllinks.py
+++ b/tests/test_htmllinks.py
@@ -169,7 +169,7 @@ class TestGetHTML(unittest.TestCase):
             self.assertIn("18-html-citeas-only", html)
             self.assertEqual("text/html;charset=UTF-8", html.content_type)
             self.assertEqual("https://w3id.example.org/a2a-fair-metrics/18-html-citeas-only/", html.requested_url)
-            self.assertEqual("https://w3id.example.org/a2a-fair-metrics/18-html-citeas-only/index.html", html.resolved_url)
+            self.assertEqual("https://w3id.example.org/a2a-fair-metrics/18-html-citeas-only/", html.resolved_url)
 
     def test_get_html_404(self):
         with requests_mock.Mocker() as m:
@@ -222,16 +222,16 @@ class TestParseHTML(unittest.TestCase):
     def test_parse_html_a2a_18(self):
         html = htmllinks.HTML(a2a_18, "text/html", 
             AbsoluteURI("https://w3id.org/a2a-fair-metrics/18-html-citeas-only/"),
-            AbsoluteURI("https://w3id.org/a2a-fair-metrics/18-html-citeas-only/index.html"))
+            AbsoluteURI("https://example.org/a2a-fair-metrics/18-html-citeas-only/"))
         signposts = htmllinks._parse_html(html)
-        self.assertEqual("https://w3id.org/a2a-fair-metrics/18-html-citeas-only/index.html", signposts.context_url)
+        self.assertEqual("https://example.org/a2a-fair-metrics/18-html-citeas-only/", signposts.context_url)
         self.assertEqual("https://w3id.org/a2a-fair-metrics/18-html-citeas-only/", signposts.citeAs.target)
-        self.assertEqual("https://w3id.org/a2a-fair-metrics/18-html-citeas-only/index.html", signposts.citeAs.context)
+        self.assertEqual("https://example.org/a2a-fair-metrics/18-html-citeas-only/", signposts.citeAs.context)
         self.assertEqual(1, len(signposts))
 
     def test_parse_html_no_head(self):
         html = htmllinks.HTML('<html><body>Hello</body></html>', "text/html",
-            AbsoluteURI("https://example.com/TODO-no-head/"),
+            AbsoluteURI("http://example.com/TODO-no-head/"),
             AbsoluteURI("https://example.com/TODO-no-head/index.html"))
         with warnings.catch_warnings(record=True) as w:
             signposts = htmllinks._parse_html(html)

--- a/tests/test_linkset.py
+++ b/tests/test_linkset.py
@@ -180,15 +180,9 @@ class TestFindSignpostingLinkset(unittest.TestCase):
         PID = "https://w3id.org/a2a-fair-metrics/14-http-describedby-citeas-linkset-json-txt-conneg/"
         for (uri,mediatype) in self._linksets_for_pid(PID):
             signposts = linkset.find_signposting_linkset(uri, mediatype)
-            if mediatype == MediaType("application/linkset+json"):
-                # Ensure Content-Location was picked up even if "uri" stayed the same
-                self.assertEqual("https://s11.no/2022/a2a-fair-metrics/14-http-describedby-citeas-linkset-json-txt-conneg/linkset.json", 
-                    signposts.context_url)
-            elif mediatype == MediaType("application/linkset"):
-                self.assertEqual("https://s11.no/2022/a2a-fair-metrics/14-http-describedby-citeas-linkset-json-txt-conneg/linkset.txt", 
-                    signposts.context_url)
-            else:
-                raise Exception("Unknown media type %s" % mediatype)
+            # Ensure Content-Location was NOT picked up to linkset.json/linkset.txt
+            self.assertEqual("https://s11.no/2022/a2a-fair-metrics/14-http-describedby-citeas-linkset-json-txt-conneg/linkset", 
+                signposts.context_url)
             
             self.assertEqual("https://w3id.org/a2a-fair-metrics/14-http-describedby-citeas-linkset-json-txt-conneg/", 
                 signposts.citeAs.target)
@@ -204,13 +198,13 @@ class TestFindSignpostingLinkset(unittest.TestCase):
                 {i.type for i in signposts.items})
 
             self.assertEqual(3, len(signposts))
-            # Assert context is picked up from anchor="" and not Content-Location
+            # Assert context is picked up from anchor="" and not redirected URL
             for s in signposts:
                 self.assertEqual("https://s11.no/2022/a2a-fair-metrics/14-http-describedby-citeas-linkset-json-txt-conneg/",
                 s.context)
 
     def test_parse_linkset_a2a_27(self):        
-        PID = "https://w3id.org/a2a-fair-metrics/27-http-linkset-json-only//"
+        PID = "https://w3id.org/a2a-fair-metrics/27-http-linkset-json-only/"
         for (uri,_) in self._linksets_for_pid(PID):
             signposts = linkset.find_signposting_linkset(uri)
             self.assertEqual("https://s11.no/2022/a2a-fair-metrics/27-http-linkset-json-only/linkset.json", signposts.context_url)

--- a/tests/test_linkset.py
+++ b/tests/test_linkset.py
@@ -45,9 +45,14 @@ class TestParseLinkset(unittest.TestCase):
         ls = linkset.Linkset(a2a_28, "application/linkset", 
             AbsoluteURI("https://s11.example.net/2022/a2a-fair-metrics/28-http-linkset-txt-only/linkset.txt"),
             AbsoluteURI("https://s11.example.net/2022/a2a-fair-metrics/28-http-linkset-txt-only/linkset.txt"))
-        signposts = linkset._parse_linkset(ls)
-        self.assertEqual("https://s11.example.net/2022/a2a-fair-metrics/28-http-linkset-txt-only/linkset.txt", signposts.context_url)
-        
+        metasignposts = linkset._parse_linkset(ls)
+        self.assertEqual("https://s11.example.net/2022/a2a-fair-metrics/28-http-linkset-txt-only/linkset.txt", metasignposts.context_url)
+
+        ## Linksets, as separate HTTP resources, may contain links for multiple context,         
+        ## therefore we have to select the right one
+        self.assertEqual({"https://s11.no/2022/a2a-fair-metrics/28-http-linkset-txt-only/"}, metasignposts.other_contexts)
+        signposts = metasignposts.for_context("https://s11.no/2022/a2a-fair-metrics/28-http-linkset-txt-only/")
+
         self.assertEqual("https://w3id.org/a2a-fair-metrics/28-http-linkset-txt-only/", signposts.citeAs.target)
 
         self.assertEqual({"https://s11.no/2022/a2a-fair-metrics/28-http-linkset-txt-only/index.ttl"},
@@ -69,9 +74,12 @@ class TestParseLinkset(unittest.TestCase):
         ls = linkset.LinksetJSON(a2a_27, "application/linkset+json", 
             AbsoluteURI("https://s11.example.net/2022/a2a-fair-metrics/27-http-linkset-json-only/linkset.json"),
             AbsoluteURI("https://s11.example.net/2022/a2a-fair-metrics/27-http-linkset-json-only/linkset.json"))
-        signposts = linkset._parse_linkset_json(ls)
-        self.assertEqual("https://s11.example.net/2022/a2a-fair-metrics/27-http-linkset-json-only/linkset.json", signposts.context_url)
-        
+        metasignposts = linkset._parse_linkset_json(ls)
+
+        self.assertEqual("https://s11.example.net/2022/a2a-fair-metrics/27-http-linkset-json-only/linkset.json", metasignposts.context_url)
+        self.assertEqual({"https://s11.no/2022/a2a-fair-metrics/27-http-linkset-json-only/"}, metasignposts.other_contexts)
+        signposts = metasignposts.for_context("https://s11.no/2022/a2a-fair-metrics/27-http-linkset-json-only/")
+
         self.assertEqual("https://w3id.org/a2a-fair-metrics/27-http-linkset-json-only/", signposts.citeAs.target)
         
         self.assertEqual({"https://s11.no/2022/a2a-fair-metrics/27-http-linkset-json-only/index.ttl"},
@@ -102,9 +110,11 @@ class TestFindSignpostingLinkset(unittest.TestCase):
     def test_parse_linkset_a2a_07(self):
         PID = "https://w3id.org/a2a-fair-metrics/07-http-describedby-citeas-linkset-json/"
         for (uri,_) in self._linksets_for_pid(PID):
-            signposts = linkset.find_signposting_linkset(uri)
-            self.assertEqual(uri, signposts.context_url)
-            
+            metasignposts = linkset.find_signposting_linkset(uri)
+            self.assertEqual(uri, metasignposts.context_url)
+            self.assertEqual({"https://s11.no/2022/a2a-fair-metrics/07-http-describedby-citeas-linkset-json/"}, metasignposts.other_contexts)
+            signposts = metasignposts.for_context("https://s11.no/2022/a2a-fair-metrics/07-http-describedby-citeas-linkset-json/")
+
             self.assertEqual("https://w3id.org/a2a-fair-metrics/07-http-describedby-citeas-linkset-json/", 
                 signposts.citeAs.target)
 
@@ -127,8 +137,10 @@ class TestFindSignpostingLinkset(unittest.TestCase):
     def test_parse_linkset_a2a_08(self):
         PID = "https://w3id.org/a2a-fair-metrics/08-http-describedby-citeas-linkset-txt/"
         for (uri,_) in self._linksets_for_pid(PID):
-            signposts = linkset.find_signposting_linkset(uri)
-            self.assertEqual(uri, signposts.context_url)
+            metasignposts = linkset.find_signposting_linkset(uri)
+            self.assertEqual(uri, metasignposts.context_url)
+            self.assertEqual({"https://s11.no/2022/a2a-fair-metrics/08-http-describedby-citeas-linkset-txt/"}, metasignposts.other_contexts)
+            signposts = metasignposts.for_context("https://s11.no/2022/a2a-fair-metrics/08-http-describedby-citeas-linkset-txt/")
             
             self.assertEqual("https://w3id.org/a2a-fair-metrics/08-http-describedby-citeas-linkset-txt/", 
                 signposts.citeAs.target)
@@ -153,9 +165,10 @@ class TestFindSignpostingLinkset(unittest.TestCase):
         PID = "https://w3id.org/a2a-fair-metrics/09-http-describedby-citeas-linkset-json-txt/"
         linksets = self._linksets_for_pid(PID)
         for (uri,mediatype) in self._linksets_for_pid(PID):
-            signposts = linkset.find_signposting_linkset(uri, mediatype)
-
-            self.assertEqual(uri, signposts.context_url)
+            metasignposts = linkset.find_signposting_linkset(uri, mediatype)
+            self.assertEqual(uri, metasignposts.context_url)
+            self.assertEqual({"https://s11.no/2022/a2a-fair-metrics/09-http-describedby-citeas-linkset-json-txt/"}, metasignposts.other_contexts)
+            signposts = metasignposts.for_context("https://s11.no/2022/a2a-fair-metrics/09-http-describedby-citeas-linkset-json-txt/")
             
             self.assertEqual("https://w3id.org/a2a-fair-metrics/09-http-describedby-citeas-linkset-json-txt/", 
                 signposts.citeAs.target)
@@ -179,11 +192,13 @@ class TestFindSignpostingLinkset(unittest.TestCase):
     def test_parse_linkset_a2a_14(self):
         PID = "https://w3id.org/a2a-fair-metrics/14-http-describedby-citeas-linkset-json-txt-conneg/"
         for (uri,mediatype) in self._linksets_for_pid(PID):
-            signposts = linkset.find_signposting_linkset(uri, mediatype)
+            metasignposts = linkset.find_signposting_linkset(uri, mediatype)
             # Ensure Content-Location was NOT picked up to linkset.json/linkset.txt
             self.assertEqual("https://s11.no/2022/a2a-fair-metrics/14-http-describedby-citeas-linkset-json-txt-conneg/linkset", 
-                signposts.context_url)
-            
+                metasignposts.context_url)
+            self.assertEqual({"https://s11.no/2022/a2a-fair-metrics/14-http-describedby-citeas-linkset-json-txt-conneg/"}, metasignposts.other_contexts)
+            signposts = metasignposts.for_context("https://s11.no/2022/a2a-fair-metrics/14-http-describedby-citeas-linkset-json-txt-conneg/")
+
             self.assertEqual("https://w3id.org/a2a-fair-metrics/14-http-describedby-citeas-linkset-json-txt-conneg/", 
                 signposts.citeAs.target)
 
@@ -206,9 +221,11 @@ class TestFindSignpostingLinkset(unittest.TestCase):
     def test_parse_linkset_a2a_27(self):        
         PID = "https://w3id.org/a2a-fair-metrics/27-http-linkset-json-only/"
         for (uri,_) in self._linksets_for_pid(PID):
-            signposts = linkset.find_signposting_linkset(uri)
-            self.assertEqual("https://s11.no/2022/a2a-fair-metrics/27-http-linkset-json-only/linkset.json", signposts.context_url)
-            
+            metasignposts = linkset.find_signposting_linkset(uri)
+            self.assertEqual("https://s11.no/2022/a2a-fair-metrics/27-http-linkset-json-only/linkset.json", metasignposts.context_url)
+            self.assertEqual({"https://s11.no/2022/a2a-fair-metrics/27-http-linkset-json-only/"}, metasignposts.other_contexts)
+            signposts = metasignposts.for_context("https://s11.no/2022/a2a-fair-metrics/27-http-linkset-json-only/")
+
             self.assertEqual("https://w3id.org/a2a-fair-metrics/27-http-linkset-json-only/", signposts.citeAs.target)
 
             self.assertEqual({"https://s11.no/2022/a2a-fair-metrics/27-http-linkset-json-only/index.ttl"},
@@ -229,9 +246,11 @@ class TestFindSignpostingLinkset(unittest.TestCase):
     def test_parse_linkset_a2a_28(self):        
         PID = "https://w3id.org/a2a-fair-metrics/28-http-linkset-txt-only/"
         for (uri,_) in self._linksets_for_pid(PID):
-            signposts = linkset.find_signposting_linkset(uri)
-            self.assertEqual("https://s11.no/2022/a2a-fair-metrics/28-http-linkset-txt-only/linkset.txt", signposts.context_url)
-            
+            metasignposts = linkset.find_signposting_linkset(uri)
+            self.assertEqual("https://s11.no/2022/a2a-fair-metrics/28-http-linkset-txt-only/linkset.txt", metasignposts.context_url)
+            self.assertEqual({"https://s11.no/2022/a2a-fair-metrics/28-http-linkset-txt-only/"}, metasignposts.other_contexts)
+            signposts = metasignposts.for_context("https://s11.no/2022/a2a-fair-metrics/28-http-linkset-txt-only/")
+
             self.assertEqual("https://w3id.org/a2a-fair-metrics/28-http-linkset-txt-only/", signposts.citeAs.target)
 
             self.assertEqual({"https://s11.no/2022/a2a-fair-metrics/28-http-linkset-txt-only/index.ttl"},


### PR DESCRIPTION
* Support multiple context in ``Signposting`` -- users of ``find_signposting_linkset`` should take particularly care to look up using ``for_context``
* RFC7231 update: Don't resolve context according to ``Content-Location`` header
