### PR TITLE
[FEATURE] Add merge/add operators

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -2,10 +2,17 @@
 Changelog
 =========
 
+* Added ``warn_duplicate`` option to ``Signposting`` constructor
+* str() on ``Signposting`` now includes ``Link`` from other contexts
+* ``Signposting`` added support for ```+``` (add) and ``|`` (merge) operations
+* Added ``Signpost`` and ``Signposting`` support for ``==`` and ``hash()``
+* Documentation improvement
+* Further code coverage by tests
+
 v0.7.2 (2022-09-26)
 ------------------------------------------------------------
 
-* Signpost/Signposting support for ``==`` and ``hash()``
+* Prototyped Signpost/Signposting support for ``==`` and ``hash()``
 * Added ``Signpost.with_context`` to change a signpost's for_context
 
 v0.7.1 (2022-08-22)

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 * str() on ``Signposting`` now includes ``Link`` from other contexts
 * ``Signposting`` added support for ```+``` (add) and ``|`` (merge) operations
 * Added ``Signpost`` and ``Signposting`` support for ``==`` and ``hash()``
+* str() on ``Signpost`` correctly shows context as ``anchor=``
 * Documentation improvement
 * Further code coverage by tests
 

--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -112,8 +112,6 @@ With *Tox*, the testing setup can be defined in a configuration file, the `tox.i
     conda install tox -c conda-forge
 
 
-One of the greatest advantages of using Tox together with the :ref:`src layout<The src layout>` is that unittest actually perform on the installed source (our package) inside an isolated deployment environment. In order words, tests are performed in an environment simulating a post-installation state instead of a pre-deploy/development environment. Under this setup, there is no need, in general cases, to distribute test scripts along with the actual source, in my honest opinion - see `MANIFEST.in`_.
-
 Before creating a Pull Request from your branch, certify that all the tests pass correctly by running:
 
 ::
@@ -121,9 +119,10 @@ Before creating a Pull Request from your branch, certify that all the tests pass
     tox
 
 These are the same tests that will be performed online in the Github Actions. 
-In addition, the above will run the integration tests, using a benchmark set of signposted resources (`a2a-fair-matrics`_) available over https. To disable these, try::
+In addition, the above will run the integration tests, using a benchmark set of signposted resources (`a2a-fair-metrics`_) available over https. To disable these, try::
 
 ::
+
     tox -e py310
 
 (replace with ``-e py37`` etc if you are running older Python versions).

--- a/docs/rst/conf.py
+++ b/docs/rst/conf.py
@@ -81,3 +81,5 @@ html_short_title = '%s-%s' % (project, version)
 napoleon_use_ivar = True
 napoleon_use_rtype = False
 napoleon_use_param = False
+
+autoclass_content = 'both'

--- a/docs/rst/usage.rst
+++ b/docs/rst/usage.rst
@@ -27,7 +27,7 @@ A convenience command line tool ``signposting`` will be installed::
 	CiteAs: <https://w3id.org/a2a-fair-metrics/05-http-describedby-citeas/>
 	DescribedBy: <https://s11.no/2022/a2a-fair-metrics/05-http-describedby-citeas/index.ttl> text/turtle
 
-A benchmark set of signposted resources (`a2a-fair-matrics`_) is provided for testing purposes. Note that the library currently only 
+A benchmark set of signposted resources (`a2a-fair-metrics`_) is provided for testing purposes. Note that the library currently only 
 support the ``"-http-"`` tests.
 
 .. _a2a-fair-metrics: https://w3id.org/a2a-fair-metrics/

--- a/src/signposting/__init__.py
+++ b/src/signposting/__init__.py
@@ -21,14 +21,14 @@ RDF library like :mod:`rdflib`.
 
 This library also provide ways to discover
 FAIR signposting in HTML ``<link>`` annotations and in
-`linkset`_ documents.  Future versions may provide ways to 
+`Link set`_ documents.  Future versions may provide ways to 
 discover/merge these concurently.
 
 .. _signposting: https://signposting.org/conventions/
 .. _FAIR: https://signposting.org/FAIR/
 .. _Link Relation: https://www.iana.org/assignments/link-relations/
 .. _rdflib: https://rdflib.readthedocs.io/en/stable/
-.. _linkset: https://signposting.org/FAIR/#linksetrec
+.. _Link set: <https://signposting.org/FAIR/#linksetrec>
 """
 
 __version__ = '0.7.2'

--- a/src/signposting/htmllinks.py
+++ b/src/signposting/htmllinks.py
@@ -25,7 +25,7 @@ from bs4 import BeautifulSoup,SoupStrainer
 from .signpost import SIGNPOSTING,AbsoluteURI,Signpost,Signposting
 
 def find_signposting_html(uri:Union[AbsoluteURI, str]) -> Signposting:
-    """Parse HTML to find <link> elements for signposting.
+    """Parse HTML to find ``<link>`` elements for signposting.
     
     HTTP redirects will be followed and any relative paths in links
     made absolute correspondingly.
@@ -36,7 +36,7 @@ def find_signposting_html(uri:Union[AbsoluteURI, str]) -> Signposting:
     :throws requests.HTTPError: If the HTTP request failed, e.g. 404 Not Found
     :throws UnrecognizedContentType: If the HTTP resource was not a recognized HTML/XHTML content type
     :throws HTMLParser.HTMLParseError: If the HTML could not be parsed.
-    :returns: A parsed `Signposting` object (which may be empty)
+    :returns: A parsed :class:`Signposting` object (which may be empty)
     """
     html = _get_html(AbsoluteURI(uri))
     return _parse_html(html)

--- a/src/signposting/resolver.py
+++ b/src/signposting/resolver.py
@@ -38,7 +38,8 @@ _http_opener = urllib.request.build_opener(_HTTPErrorHandler)
 def find_signposting_http(url: str) -> Signposting:
     """Find signposting from HTTP headers.
 
-    Return a parsed `Signposting` object of the discovered signposting.
+    :param url: The URL to request HTTP ``Link`` headers from using HTTP ``HEAD``
+    :return: A parsed :class:`Signposting` object of the discovered signposting
     """
     req = urllib.request.Request(url, method="HEAD")
     link_headers: List[str] = []  # Fall-back: No links

--- a/src/signposting/signpost.py
+++ b/src/signposting/signpost.py
@@ -446,7 +446,8 @@ class Signposting(Iterable[Signpost], Sized):
     def __init__(self, 
                  context_url: Union[AbsoluteURI, str] = None, 
                  signposts: Iterable[Signpost] = None,
-                 include_no_context: bool = True):
+                 include_no_context: bool = True,
+                 warn_duplicate=True):
         """Construct a Signposting from a list of :class:`Signpost`s.
 
         Signposts are filtered by the matching `context_url` (if provided), 
@@ -469,6 +470,7 @@ class Signposting(Iterable[Signpost], Sized):
             assuming they are about ``context_url``. 
             If false, such signposts are ignored for assignment, 
             but remain available from :attr:`signposts`.
+        :param warn_duplicate: If true (default), warn of duplicate signposts that can't be assigned.
         :raise ValueError: If ``include_no_context`` is false, but ``context_url`` was not provided or None.
         """
         if not include_no_context and not context_url:
@@ -509,19 +511,19 @@ class Signposting(Iterable[Signpost], Sized):
                     self.other_contexts.add(context)
             elif s.rel is LinkRel.cite_as:
                 if self.citeAs and self.citeAs.target != s.target:
-                    warn("Ignoring additional cite-as signposts")
+                    warn("Ignoring additional cite-as signposts") if warn_duplicate else None
                     self._extras.add(s)
                 else:
                     self.citeAs = s
             elif s.rel is LinkRel.license:
                 if self.license and self.license.target != s.target:
-                    warn("Ignoring additional license signposts")
+                    warn("Ignoring additional license signposts") if warn_duplicate else None
                     self._extras.add(s)
                 else:
                     self.license = s
             elif s.rel is LinkRel.collection:
                 if self.collection and self.collection.target != s.target:
-                    warn("Ignoring additional collection signposts")
+                    warn("Ignoring additional collection signposts") if warn_duplicate else None
                     self._extras.add(s)
                 else:
                     self.collection = s
@@ -807,4 +809,4 @@ class Signposting(Iterable[Signpost], Sized):
             to_add = (s for s in other if s.context == self.context_url or not s.context)
         return Signposting(self.context_url, itertools.chain(to_add, self.signposts), 
             # NOTE: We chain the added ones first so they can override the singular properties like citeAs
-                include_no_context=True)
+                include_no_context=True, warn_duplicate=False)

--- a/src/signposting/signpost.py
+++ b/src/signposting/signpost.py
@@ -559,7 +559,7 @@ class Signposting(Iterable[Signpost], Sized):
                 yield s
         for o in self._others:
             if not o.context:
-                warn("Ignoring signpost with unknown context: " % o)
+                warn("Ignoring signpost with unknown context: %s" % o)
                 continue
             yield o
 
@@ -585,7 +585,7 @@ class Signposting(Iterable[Signpost], Sized):
         include_no_context = context_uri is None
         if include_no_context:
             # include any implicit contexts as-is
-            our_signposts = self.signposts
+            our_signposts: Iterable[Signpost] = self.signposts
         else:
             # ensure explicit contexts, so they don't get lost
             our_signposts = self._signposts_with_explicit_context()
@@ -752,7 +752,7 @@ class Signposting(Iterable[Signpost], Sized):
         newContext = self.context_url or other.context_url or None
         if newContext:
             # Merge with explicit contexts so that Signposts can be compared
-            merged = set(itertools.chain(self._signposts_with_explicit_context(), 
+            merged: Iterable[Signpost] = set(itertools.chain(self._signposts_with_explicit_context(), 
                     other._signposts_with_explicit_context()))
         else:
             # Both are context-free, merge them as-is
@@ -802,9 +802,9 @@ class Signposting(Iterable[Signpost], Sized):
         if (isinstance(other, Signposting) and 
                 self.context_url and other.context_url and 
                 other.context_url != self.context_url):
-            to_add = other.for_context(self.context_url)
+            to_add: Iterable[Signpost] = other.for_context(self.context_url)
         else:
             to_add = (s for s in other if s.context == self.context_url or not s.context)
-        return Signposting(self, itertools.chain(to_add, self.signposts), 
+        return Signposting(self.context_url, itertools.chain(to_add, self.signposts), 
             # NOTE: We chain the added ones first so they can override the singular properties like citeAs
                 include_no_context=True)

--- a/src/signposting/signpost.py
+++ b/src/signposting/signpost.py
@@ -48,16 +48,13 @@ from httplink import Link
 class AbsoluteURI(str):
     """An absolute URI, e.g. "http://example.com/" """
     def __new__(cls, value: str, base: Optional[str] = None):
-        """Create an absolute URI reference.
+        """Create and validate an absolute URI reference.
 
-        If the base parameter is given, it is used to resolve the
-        potentially relative URI reference, otherwise the first argument
-        must be an absolute URI.
+        Note that IRIs are not supported unless ``%``-encoded.
 
-        This constructor will throw `ValueError` if the
-        final URI reference is invalid or not absolute.
-
-        Note that IRIs are not supported.
+        :param value: URI string to validate as Absolute URI. May be a relative URI reference if `base` is provided.
+        :param base: (Optional) URI used to resolve the potentially relative URI reference, otherwise `value` must be an absolute URI.
+        :raise ValueError: if the final URI reference is invalid or not absolute.
         """
         if isinstance(value, cls):
             return value # Already AbsoluteURI, no need to check again
@@ -80,15 +77,15 @@ class AbsoluteURI(str):
 
 
 class MediaType(str):
-    """An IANA media type, e.g. text/plain.
+    """An IANA media type, e.g. ``text/plain``.
 
     This class ensures the type string is valid according to `RFC6838`_
     and for convenience converts it to lowercase.
 
     While the constructor do check that the main type is an offical IANA subtree
-    (see `MediaType.MAIN`), it does not enforce the individual subtype to be registered.
+    (see :attr:`MAIN`), it does not enforce the individual subtype to be registered.
     In particular RFC6838 permits unregistered subtypes
-    starting with `vnd.`, `prs.` and `x.`
+    starting with ``vnd.``, ``prs.`` and ``x.``
 
     Extra content type parameters such as ``;profile=http://example.com/`` are
     **not** supported by this class, as they do not form part of the
@@ -114,10 +111,10 @@ class MediaType(str):
     """
 
     main: str
-    """The main type, e.g. image"""
+    """The main type, e.g. ``image``"""
 
     sub: str
-    """The sub-type, e.g. jpeg"""
+    """The sub-type, e.g. ``jpeg``"""
 
     def __new__(cls, value=str):
         """Construct a MediaType.
@@ -156,8 +153,8 @@ class LinkRel(str, Enum):
     only link relations listed in `FAIR`_ and `signposting`_
     conventions are included in this enumerator.
 
-    A link relation enum can be looked up from its RFC8288 _value_
-    by calling ``LinkRel("cite-as")`` - note that this particular
+    A link relation enum can be looked up from its RFC8288 *value*
+    by calling ``LinkRel("cite-as")`` -- note that this particular
     example has a different Python-compatible spelling in it's
     enum *name* (``LinkRel.cite_as``).
 
@@ -191,7 +188,7 @@ class Signpost:
     or otherwise constructed.
 
     In some case the link relation may have additional attributes,
-    e.g. ``signpost.link["title"]`` - the purpose of this class is however to
+    e.g. ``signpost.link["title"]`` -- the purpose of this class is however to
     lift only the navigational attributes for FAIR Signposting.
     """
 
@@ -262,7 +259,6 @@ class Signpost:
         :param link: Optional origin :class:`Link` header (not parsed further) for further attributes
 
         :raise ValueError: If a plain string value is invalid for the corresponding type-checked classes :class:`LinkRel`, :class:`AbsoluteURI` or :class:`MediaType`,
-
         """
 
         if isinstance(rel, LinkRel):
@@ -397,7 +393,7 @@ class Signposting(Iterable[Signpost], Sized):
 
     other_contexts: Set[AbsoluteURI]
     """Other resource URLs which signposting has been provided for. 
-    
+
     Use :meth:`for_context` to retrieve their signpostings, or filter the full list of signposts from :attr:`signposts` according to :attr:`Signpost.context`
     """
 

--- a/src/signposting/signpost.py
+++ b/src/signposting/signpost.py
@@ -208,7 +208,7 @@ class Signpost:
     retrieving the target URI.
 
     This property is optional, and should only be expected
-    if `rel` is :const:`LinkRel.describedby` or :const:`LinkRel.item`
+    if ``rel`` is :const:`LinkRel.describedby` or :const:`LinkRel.item`
     """
 
     # FIXME: Correct JSON-LD profile
@@ -231,16 +231,16 @@ class Signpost:
     from the one originally requested.
 
     This attribute is optional (with ``None`` indicating unknown context),
-    however producers of ``Signpost`` instances from are encouraged to 
-
+    context may be implied from the resource, e.g. as indicated by 
+    :attr:`Signposting.context_url`
     """
 
     link: Optional[Link]
-    """The Link object this signpost was created from.
+    """The :class:`Link` object this signpost was created from.
 
     May contain additional attributes such as ``link["title"]``.
-    Note that a single Link may have multiple ``rel``s, therefore it is
-    possible that multiple :class:`Signpost` refer to the same link.
+    Note that a single Link may have multiple ``rel`` relations, therefore it is
+    possible that multiple :class:`Signpost` instances refer to the same link.
     """
 
     def __init__(self,
@@ -363,7 +363,7 @@ class Signpost:
     def with_context(self, context: Union[AbsoluteURI, str, None]) -> Signpost:
         """Create a copy of this signpost, but with the specified context.
         
-        If the context is None, it means the copy will not have a context.
+        If the context is ``None``, it means the copy will not have a context.
         """
         return Signpost(self.rel, self.target, self.type, self.profiles, context, self.link)
 
@@ -371,10 +371,10 @@ class Signposting(Iterable[Signpost], Sized):
     """Signposting links for a given resource.
 
     Links are categorized according to `FAIR`_ `signposting`_ conventions and 
-    split into different attributes like `citeAs` or `describedBy`.
+    split into different attributes like :attr:`citeAs` or :attr:`describedBy`.
 
-    It is possible to iterate over this class or use the `signposts` property to
-    find all recognized signposts.
+    It is possible to iterate over this class or use the :attr:`signposts` 
+    property to find all recognized signposts.
 
     Note that in the case of a resource not having any signposts, instances
     of this class are considered false.
@@ -403,7 +403,7 @@ class Signposting(Iterable[Signpost], Sized):
     describedBy: Set[Signpost]
     """Metadata resources about this resource and its items, typically in a Linked Data format.
 
-    Resources may require content negotiation, check `Signpost.type` attribute
+    Resources may require content negotiation, check :attr:`Signpost.type` attribute
     (if present) for content type, e.g. ``text/turtle``.
     """
 
@@ -413,7 +413,7 @@ class Signposting(Iterable[Signpost], Sized):
     items: Set[Signpost]
     """Items contained by this resource, e.g. downloads.
 
-    The content type of the download may be available as `Signpost.type` attribute.
+    The content type of the download may be available as :attr:`Signpost.type` attribute.
     """
 
     linksets: Set[Signpost]
@@ -421,7 +421,7 @@ class Signposting(Iterable[Signpost], Sized):
 
     A `Linkset`_ is a JSON or text serialization of Link headers available as a
     separate resource, and may be used to externalize large collection of links, e.g.
-    thousands of "item" relations.
+    thousands of ``item`` relations.
 
     Resources may require content negotiation, check ``Link["type"]`` attribute
     (if present)  for content types ``application/linkset`` or ``application/linkset+json``.
@@ -443,7 +443,7 @@ class Signposting(Iterable[Signpost], Sized):
                  signposts: Iterable[Signpost] = None,
                  include_no_context: bool = True,
                  warn_duplicate=True):
-        """Construct a Signposting from a list of :class:`Signpost`s.
+        """The constructor takes a an iterable of :class:`Signpost`.
 
         Signposts are filtered by the matching `context_url` (if provided), 
         then assigned to attributes like :attr:`citeAs` or :attr:`describedBy`
@@ -456,17 +456,17 @@ class Signposting(Iterable[Signpost], Sized):
         A Signposting object is equivalent to boolean `False` in conditional expression 
         if it is empty, that is ``len(signposting)==0``, indicating no signposts 
         were discovered for the given context. However the remaining 
-        ``signposts`` will still be available from :attr:`signposts`, as
-        indicated by :attr:`other_contexts`.
+        signposts will still be available from :attr:`signposts`, as
+        indicated by :attr:`other_contexts` and retrievable with :meth:`for_context`.
         
         :param context_url: the resource to select signposting for, or any signposts if ``None``.            
-        :param signposts: An iterable of :class:`Signpost`s that should be considered for selecting signposting.
-        :param include_no_context: If true (default), consider signposts without explicit context, 
+        :param signposts: An iterable of :class:`Signpost` that should be considered for selecting signposting.
+        :param include_no_context: If `True` (default), consider signposts without explicit context, 
             assuming they are about ``context_url``. 
-            If false, such signposts are ignored for assignment, 
+            If `False`, such signposts are ignored for assignment, 
             but remain available from :attr:`signposts`.
-        :param warn_duplicate: If true (default), warn of duplicate signposts that can't be assigned.
-        :raise ValueError: If ``include_no_context`` is false, but ``context_url`` was not provided or None.
+        :param warn_duplicate: If `True` (default), warn of duplicate signposts that can't be assigned.
+        :raise ValueError: If ``include_no_context`` is false, but ``context_url`` was not provided or `None`.
         """
         if not include_no_context and not context_url:
             raise ValueError("Can't exclude signposts without context when not providing context_url; try include_no_context=True")
@@ -542,8 +542,8 @@ class Signposting(Iterable[Signpost], Sized):
         """All FAIR Signposts with recognized relation types.
         
         This may include any additional signposts for link relations
-        that only expect a single link, like :prop:`citeAs`, as well
-        as any signposts for other contexts as listed in :prop:`other_contexts`.
+        that only expect a single link, like :attr:`citeAs`, as well
+        as any signposts for other contexts as listed in :attr:`other_contexts`.
         """
         return frozenset(itertools.chain(self, self._others))
 
@@ -567,33 +567,34 @@ class Signposting(Iterable[Signpost], Sized):
                 continue
             yield o
 
-    def for_context(self, context_uri:Union[AbsoluteURI, str, None]) -> Signposting:
+    def for_context(self, context_url:Union[AbsoluteURI, str, None]) -> Signposting:
         """Return signposting for given context URI.
         
-        This will select an alternative view of the signposts from :attr:`signposts`
-        filtered by the given ``context_uri``.
+        This will select an alternative view of the :attr:`signposts`
+        filtered by the given ``context_url``.
 
         The remaining signposts and their contexts will be included under 
-        :attr:`Signpost.signposts` -- any signposts with implicit context will
-        be replaced with having an explicit context :attr:`self.context_url`.
+        :attr:`signposts` -- any signposts with implicit context will
+        be replaced with having an explicit context from :attr:`context_url`.
 
         **Tip**: To ensure all signposts have explicit context, use 
-        ``s.for_context(s.context_uri)``
+        ``s.for_context(s.context_url)``
 
-        :param context_uri: The context to select signposts from. 
-            The URI should be a member of :attr:`contexts` or equal to :attr:`context`, 
+        :param context_url: The context to select signposts from. 
+            The URI should be a member of :attr:`other_contexts` or equal to :attr:`context_url`, 
             otherwise the returned Signposting will be empty.
-            If the context_uri is `None`, then the :attr:`Signpost.context` is ignored
-            and any signposts will be considered.
+
+            If this parameter is `None`, then the individual :attr:`Signpost.context` 
+            values are ignored and any signposts will be considered.
         """
-        include_no_context = context_uri is None
+        include_no_context = context_url is None
         if include_no_context:
             # include any implicit contexts as-is
             our_signposts: Iterable[Signpost] = self.signposts
         else:
             # ensure explicit contexts, so they don't get lost
             our_signposts = self._signposts_with_explicit_context()
-        return Signposting(context_uri, 
+        return Signposting(context_url, 
                            our_signposts,
                            include_no_context=include_no_context)
 
@@ -638,7 +639,7 @@ class Signposting(Iterable[Signpost], Sized):
         context, loaded from two different contexts.
 
         **Tip**: To compare two Signposting's using only explicit ``Signpost.context``s, use
-        ``a.for_context(a.context_uri) == b.for_context(b.context_uri)``
+        ``a.for_context(a.context_url) == b.for_context(b.context_url)``
         """
         if not isinstance(o, Signposting):
             return False
@@ -783,7 +784,7 @@ class Signposting(Iterable[Signpost], Sized):
         this method will iterate over its direct signposts only if its context is ``None`` or matches
         the current context, otherwise it will select the current context using :meth:`Signposting.for_context`.
         
-        If the added Signpost's context is `None` or match the current :attr:`context_uri`` 
+        If the added Signpost's context is `None` or match the current :attr:`context_url`` 
         they will __replace__ or append the existing signposts from this instance. 
         
         For instance, if the left-hand Signpost ``a`` had::

--- a/src/signposting/signpost.py
+++ b/src/signposting/signpost.py
@@ -323,7 +323,7 @@ class Signpost:
         if self.profiles:
             strs.append('profile="%s"' % " ".join(self.profiles))
         if self.context:
-            strs.append('context="%s"' % self.context)
+            strs.append('anchor="%s"' % self.context)
         return "; ".join(strs)
 
     def _eq_attribs(self) -> Iterable[object]:

--- a/src/signposting/signpost.py
+++ b/src/signposting/signpost.py
@@ -713,21 +713,22 @@ class Signposting(Iterable[Signpost], Sized):
         c) No context
         
         When merging Signpost, any implicit contexts are made explicit
-        from their original Signposting's context, if specified. 
+        from their original :attr:`Signposting.context_url` if specified. 
         
-        Duplicate Signpost (as determined by ::meth::``Signpost.__eq__``) will be ignored, 
-        it is unspecified which Signpost will be rejected 
-        (this should primarily affects attr::``Signpost.link``).
-
-        If neither Signposting has a context, then the new Signposting 
+        If neither Signposting has a context, then the new `Signposting`
         is constructed with ``include_no_context=True`` meaning that only
         signposts _without_ context are considered. Otherwise only
-        signpost _with_ the determined context are considered.
+        signpost _with_ the determined context are considered. 
+        (Tip: To adapt signposts without context, use :meth:`Signposting.__add__` instead)
 
-        If multiple signposts match singular properties like ::attr::``citeAs`` but with 
-        different targets, it is undefined which Signpost will be selected after merging,
-        however all signposts will be included in the iteration over the returned
-        ``Signposting``.
+        If multiple signposts match singular properties like :attr:`citeAs` but with 
+        different targets, Signpost from this instance (left-hand) 
+        will be preferred after merging, however all signposts will be 
+        included in the iteration over the returned ``Signposting``. 
+
+        Duplicate Signpost (as determined by :meth:`Signpost.__eq__`) 
+        will be ignored, it is unspecified which Signpost will be rejected 
+        (this should primarily affects :attr:`Signpost.link`).
 
         As an example, if the left-hand Signpost ``a`` with context ``http://example.com/doc/1`` had::
 
@@ -745,14 +746,16 @@ class Signposting(Iterable[Signpost], Sized):
             Link <http://example.com/author/1>;rel=author;context="http://example.com/doc/1"
             Link <http://example.com/author/2>;rel=author;context="http://example.com/doc/1"
 
-        In this case ``pid/B`` is ignored in the merged signposting as it relates to ``doc/2` 
+        In this case ``…pid/B`` is ignored in the merged signposting as it relates to ``…doc/2`` 
         and not the determined context ``http://example.com/doc/1``, which on the other hand
         has been made explicit in all its direct signposts.
 
         The complete set of merged signposts (regardless of their context) 
-        is available in :attr::``Signposting.signposts`` in the returned instance.
+        is available in :attr:`Signposting.signposts` in the returned instance.
 
-        :raise TypeError: If ``other`` is not an instance of ``Signposting``
+        :param other: Another `Signposting` instance which signposts are to be merged with ours
+        :return: A new `Signposting` instance from the merged list of signposts. 
+        :raise TypeError: If `other` is not an instance of `Signposting`
         """
         if not isinstance(other, Signposting):
             raise TypeError("Can only merge with Signposting instances, not: " % type(other))
@@ -775,12 +778,12 @@ class Signposting(Iterable[Signpost], Sized):
 
         The returned Signposting instance will have the same context as this instance.
 
-        ``other`` is considered an iterable of ``Signpost``s -- if it is a ``Signposting`` instance,
+        `other` is considered an iterable of `Signpost`s -- if it is a `Signposting` instance,
         this method will iterate over its direct signposts only if its context is ``None`` or matches
-        the current context, otherwise it will select the current context using ``Signposting.for_context``.
+        the current context, otherwise it will select the current context using :meth:`Signposting.for_context`.
         
-        If the Signpost's context is ``None`` or match the current ::attr:``context_uri``, 
-        they will replace or append the existing signposts from this instance. 
+        If the added Signpost's context is `None` or match the current :attr:`context_uri`` 
+        they will __replace__ or append the existing signposts from this instance. 
         
         For instance, if the left-hand Signpost ``a`` had::
 
@@ -798,16 +801,20 @@ class Signposting(Iterable[Signpost], Sized):
             Link <http://example.com/author/1>;rel=author``
             Link <http://example.com/author/2>;rel=author
 
-        (Note: iterating over the returned ``Signposting`` would include the relegated ``pid/A``. 
+        (Note: iterating over the returned `Signposting` would include the relegated ``…pid/A``. 
         Take care of operatand order if adding multiple Signpostings).
         
         Added signposts with other contexts will be ignored and
-        __not__ added to the resulting ``signposts``, however existing 
+        __not__ added to the resulting `signposts`, however existing 
         signposts from other contexts in this instance are preserved.
 
-        To do a full merge across contexts, use instead ``a | b``, see ::meth::__or__
+        To do a full merge across contexts, use instead ``a | b``, see :meth:`__or__`
 
-        :raise TypeError: If ``other`` is not an instance of ``Signposting`` or an iterable of Signposts.
+        :param other: Either an `Iterable` (`Set`, `List`, etc) of `Signpost` instances, or another `Signposting` instance.
+            The signposts are to be added to our signposts, if matching the determined context.
+        :return: A new `Signposting` instance from the summed list of signposts. 
+            Signposts from `other` may overridde signposts from this instance.
+        :raise TypeError: If `other` is not an instance of `Signposting` or an iterable of Signposts.
         """
         if (isinstance(other, Signposting) and 
                 self.context_url and other.context_url and 

--- a/src/signposting/signpost.py
+++ b/src/signposting/signpost.py
@@ -582,7 +582,7 @@ class Signposting(Iterable[Signpost], Sized):
         :attr:`Signpost.signposts` -- any signposts with implicit context will
         be replaced with having an explicit context :attr:`self.context_url`.
 
-        Tip: To ensure all signposts have explicit context, use 
+        **Tip**: To ensure all signposts have explicit context, use 
         ``s.for_context(s.context_uri)``
 
         :param context_uri: The context to select signposts from. 
@@ -641,6 +641,9 @@ class Signposting(Iterable[Signpost], Sized):
         although each :attr:`Signpost.context` are included when comparing list of signposts. 
         This distinction becomes significant when comparing signposts without explicit
         context, loaded from two different contexts.
+
+        **Tip**: To compare two Signposting's using only explicit ``Signpost.context``s, use
+        ``a.for_context(a.context_uri) == b.for_context(b.context_uri)``
         """
         if not isinstance(o, Signposting):
             return False
@@ -719,7 +722,8 @@ class Signposting(Iterable[Signpost], Sized):
         is constructed with ``include_no_context=True`` meaning that only
         signposts _without_ context are considered. Otherwise only
         signpost _with_ the determined context are considered. 
-        (Tip: To adapt signposts without context, use :meth:`Signposting.__add__` instead)
+        
+        **Tip**: To adapt signposts without context, use :meth:`Signposting.__add__` instead
 
         If multiple signposts match singular properties like :attr:`citeAs` but with 
         different targets, Signpost from this instance (left-hand) 

--- a/src/signposting/signpost.py
+++ b/src/signposting/signpost.py
@@ -697,14 +697,16 @@ class Signposting(Iterable[Signpost], Sized):
         return "<Signposting %s>" % "\n ".join(repr)
 
     def __str__(self) -> str:
-        """Represent signposts as HTTP Link headers.
+        """Represent all :atttr:`signposts` as HTTP Link headers.
         
         Note that these are reconstructed from the recognized link relations only,
-        and do not include unparsed additional link attributes or links with different contexts.
+        and do not include unparsed additional link attributes.
+        
+        Signposts with other contexts are included in this listing.
 
         See also `Signpost.link`
         """
-        return "\n".join(map(str, self))
+        return "\n".join(map(str, self.signposts))
 
     def __or__(self, other: Signposting) -> Signposting:
         """Merge two Signposting instances.

--- a/src/signposting/signpost.py
+++ b/src/signposting/signpost.py
@@ -243,7 +243,7 @@ class Signpost:
 
     May contain additional attributes such as ``link["title"]``.
     Note that a single Link may have multiple ``rel``s, therefore it is
-    possible that multiple :class:`Signpost`s refer to the same link.
+    possible that multiple :class:`Signpost` refer to the same link.
     """
 
     def __init__(self,
@@ -398,7 +398,7 @@ class Signposting(Iterable[Signpost], Sized):
     other_contexts: Set[AbsoluteURI]
     """Other resource URLs which signposting has been provided for. 
     
-    Use :meth:`for_context` to retrieve their signpostings, or filter the full list of signposts from :prop:`signposts` according to :attr:`Signpost.context`
+    Use :meth:`for_context` to retrieve their signpostings, or filter the full list of signposts from :attr:`signposts` according to :attr:`Signpost.context`
     """
 
     authors: Set[Signpost]
@@ -423,14 +423,14 @@ class Signposting(Iterable[Signpost], Sized):
     linksets: Set[Signpost]
     """Linkset resources with further signposting for this resource (and potentially others).
 
-    A `linkset`_ is a JSON or text serialization of Link headers available as a
+    A `Linkset`_ is a JSON or text serialization of Link headers available as a
     separate resource, and may be used to externalize large collection of links, e.g.
     thousands of "item" relations.
 
     Resources may require content negotiation, check ``Link["type"]`` attribute
     (if present)  for content types ``application/linkset`` or ``application/linkset+json``.
 
-    .. _linkset: https://datatracker.ietf.org/doc/draft-ietf-httpapi-linkset/
+    .. _Linkset: https://datatracker.ietf.org/doc/draft-ietf-httpapi-linkset/
     """
 
     citeAs: Optional[Signpost]

--- a/src/signposting/signpost.py
+++ b/src/signposting/signpost.py
@@ -689,3 +689,8 @@ class Signposting(Iterable[Signpost], Sized):
         See also `Signpost.link`
         """
         return "\n".join(map(str, self))
+
+    def __or__(self, other):
+        if not isinstance(other, Signposting):
+            raise ValueError("Can only merge with Signposting instances, not: " % type(other))
+        

--- a/src/signposting/signpost.py
+++ b/src/signposting/signpost.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 
 import itertools
 import re
-from types import NoneType
 from typing import Collection, Iterable, Iterator, List, Optional, Set, Sized, Tuple, Union, AbstractSet, FrozenSet
 from enum import Enum, auto, unique
 from warnings import warn

--- a/tests/test_signpost.py
+++ b/tests/test_signpost.py
@@ -564,13 +564,14 @@ class TestSignposting(unittest.TestCase):
     def testStrItemContext(self):
         s = str(Signposting("http://example.com/page1",
                  [Signpost(LinkRel.item, "http://example.com/file/2.txt", context="http://example.com/page1")]))
-        self.assertEqual('Link: <http://example.com/file/2.txt>; rel=item; context="http://example.com/page1"', s)
+        # Notice context is called anchor
+        self.assertEqual('Link: <http://example.com/file/2.txt>; rel=item; anchor="http://example.com/page1"', s)
 
     def testStrItemOtherContext(self):
         s = str(Signposting("http://example.com/page1",
                  [Signpost(LinkRel.item, "http://example.com/file/2.txt", context="http://example.com/page2")]))
         # NOTE: All signposts are included in str()
-        self.assertEqual('Link: <http://example.com/file/2.txt>; rel=item; context="http://example.com/page2"', s)
+        self.assertEqual('Link: <http://example.com/file/2.txt>; rel=item; anchor="http://example.com/page2"', s)
 
     def testConstructorItems(self):
         s = Signposting("http://example.com/page1", [

--- a/tests/test_signpost.py
+++ b/tests/test_signpost.py
@@ -527,7 +527,7 @@ class TestSignposting(unittest.TestCase):
 
     def testStrDefault(self):
         s = Signposting("http://example.com/page1")
-        self.assertEqual("", str(s)) # no Link headers
+        self.assertEqual("", str(s)) # empty, no Link headers
 
     def testConstructorEmpty(self):
         s = Signposting("http://example.com/page1", [])
@@ -561,6 +561,16 @@ class TestSignposting(unittest.TestCase):
                  [Signpost(LinkRel.item, "http://example.com/file/2.txt", media_type=MediaType("text/plain"))]))
         self.assertEqual('Link: <http://example.com/file/2.txt>; rel=item; type="text/plain"', s)
 
+    def testStrItemContext(self):
+        s = str(Signposting("http://example.com/page1",
+                 [Signpost(LinkRel.item, "http://example.com/file/2.txt", context="http://example.com/page1")]))
+        self.assertEqual('Link: <http://example.com/file/2.txt>; rel=item; context="http://example.com/page1"', s)
+
+    def testStrItemOtherContext(self):
+        s = str(Signposting("http://example.com/page1",
+                 [Signpost(LinkRel.item, "http://example.com/file/2.txt", context="http://example.com/page2")]))
+        # NOTE: All signposts are included in str()
+        self.assertEqual('Link: <http://example.com/file/2.txt>; rel=item; context="http://example.com/page2"', s)
 
     def testConstructorItems(self):
         s = Signposting("http://example.com/page1", [

--- a/tests/test_signpost.py
+++ b/tests/test_signpost.py
@@ -944,12 +944,46 @@ class TestSignposting(unittest.TestCase):
         # Now with explicit context
         self.assertEqual("http://example.com/doc1", c.citeAs.context)        
         self.assertEqual(2, len(c)) # as only doc1 is focus by the determined context
+        # They didn't match context
+        self.assertNotIn("http://example.com/pid/A", {s.target for s in c})
+        self.assertNotIn("http://example.com/author/1", {s.target for s in c})
+        # But they survive here
+        self.assertIn("http://example.com/pid/A", {s.target for s in c.signposts})
+        self.assertIn("http://example.com/author/1", {s.target for s in c.signposts})
+        # Their context was NOT rewritten as there was nothing to assign
+        self.assertEqual({None}, {s.context for s in c.signposts if s.target=="http://example.com/pid/A"})
+        self.assertEqual({None}, {s.context for s in c.signposts if s.target=="http://example.com/author/1"})
 
+    def testMergeOtherContext(self):
+        a = Signposting(signposts=[
+            Signpost(LinkRel.cite_as, "http://example.com/pid/A"),
+            Signpost(LinkRel.author, "http://example.com/author/1"),
+        ])
+        b = Signposting(context_url="http://example.com/doc1", signposts=[
+            Signpost(LinkRel.cite_as, "http://example.com/pid/B"),
+            Signpost(LinkRel.author, "http://example.com/author/2"),
+        ])
+        c = a|b
+        # as A didn't have a context
+        self.assertEqual(b.context_url, c.context_url)
+        self.assertEqual({"http://example.com/author/2"},
+            {a.target for a in c.authors})
+                    
+        # as that is the PID of the existing context
+        self.assertEqual("http://example.com/pid/B", c.citeAs.target)
+        # Now with explicit context
+        self.assertEqual("http://example.com/doc1", c.citeAs.context)        
+        self.assertEqual(2, len(c)) # as only doc1 is focus by the determined context
+        # They didn't match context
         self.assertNotIn("http://example.com/pid/A", {s.target for s in c})
         self.assertNotIn("http://example.com/author/1", {s.target for s in c})
         # But they survive here:
         self.assertIn("http://example.com/pid/A", {s.target for s in c.signposts})
         self.assertIn("http://example.com/author/1", {s.target for s in c.signposts})
+        # Their context was NOT rewritten as there was nothing to assign
+        self.assertEqual({None}, {s.context for s in c.signposts if s.target=="http://example.com/pid/A"})
+        self.assertEqual({None}, {s.context for s in c.signposts if s.target=="http://example.com/author/1"})
+
 
     def testMergeDefaultContext(self):        
         a = Signposting(context_url="http://example.com/doc1", signposts=[
@@ -971,7 +1005,7 @@ class TestSignposting(unittest.TestCase):
         # Now with explicit context
         self.assertEqual("http://example.com/doc1", c.citeAs.context)        
         self.assertEqual(2, len(c)) # as only doc1 is focus by the determined context
-
+        # They didn't match context
         self.assertNotIn("http://example.com/pid/B", {s.target for s in c})
         self.assertNotIn("http://example.com/author/2", {s.target for s in c})
         # But they survive here:


### PR DESCRIPTION
* Added ``warn_duplicate`` option to ``Signposting`` constructor
* str() on ``Signposting`` now includes ``Link`` from other contexts
* ``Signposting`` added support for ```+``` (add) and ``|`` (merge) operations
* Added ``Signpost`` and ``Signposting`` support for ``==`` and ``hash()``
* Documentation improvement
* Further code coverage by tests