### PR TITLE
Allow fragments in profile URIs

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
     orcid: https://orcid.org/0000-0001-8250-4074"
 title: "Signposting link parser library"
 doi: 10.5281/zenodo.6815412
-version: 0.9.0
+version: 0.9.1
 license: Apache-2.0
 repository-code: "https://github.com/stain/signposting/"
 keywords:

--- a/codemeta.json
+++ b/codemeta.json
@@ -9,7 +9,7 @@
     "downloadUrl": "https://github.com/stain/signposting/releases",
     "issueTracker": "https://github.com/stain/signposting/issues",
     "name": "Signposting link parser library",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "identifier": "10.5281/zenodo.6815412",
     "applicationCategory": "Web",
     "funding": [

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * Added `CITATION.cff`
+* Allow `#fragments` in profile URIs (e.g. for JSON-LD)
 
 v0.9.1 (2022-10-03)
 ------------------------------------------------------------

--- a/src/signposting/signpost.py
+++ b/src/signposting/signpost.py
@@ -63,7 +63,7 @@ class AbsoluteURI(str):
         # Resolve potentially relative URI reference when base is given
         uri = urljoin(base or "", value)
         # will throw ValueError if resolved URI is not valid
-        rfc3987.parse(uri, rule="absolute_URI")
+        rfc3987.parse(uri, rule="URI")
         return super(AbsoluteURI, cls).__new__(cls, uri)
 
     # @staticmethod

--- a/src/signposting/signpost.py
+++ b/src/signposting/signpost.py
@@ -665,7 +665,7 @@ class Signposting(Iterable[Signpost], Sized):
         """
         h = hash(self.__class__.__qualname__)
         # NOTE context is NOT included in equality checks, see __eq__
-        ## h ^= self.context
+        ## h ^= hash(self.context)
         for e in self:
             # We use a naive XOR here as order should NOT matter
             h ^= hash(e)

--- a/tests/test_signpost.py
+++ b/tests/test_signpost.py
@@ -337,6 +337,27 @@ class TestSignpost(unittest.TestCase):
                 profiles="https:/example.org/first-ok second-not-absolute"
                 )
 
+    def testConstructorHashProfile(self):
+        s = Signpost(
+            LinkRel.describedby,
+            "http://example.com/workflows/12/ro-crate-metadata.json",
+            "application/ld+json",
+            # Multiple JSON-LD profiles with #hashes as in 
+            # https://www.researchobject.org/ro-crate/1.1/appendix/jsonld.html#ro-crate-json-ld-media-type
+            "http://www.w3.org/ns/json-ld#flattened http://www.w3.org/ns/json-ld#compacted https://w3id.org/ro/crate")
+        self.assertEqual("describedby", s.rel.value)
+        self.assertEqual("http://example.com/pid/1", str(s.target))
+        self.assertEqual("application/ld+json", str(s.type))
+        self.assertTrue(AbsoluteURI(
+            "http://www.w3.org/ns/json-ld#flattened") in s.profiles)
+        self.assertTrue(AbsoluteURI(
+            "http://www.w3.org/ns/json-ld#compacted") in s.profiles)
+        self.assertTrue(AbsoluteURI(
+            "http://www.w3.org/ns/json-ld#compacted") in s.profiles)
+        self.assertTrue(AbsoluteURI(
+            "https://w3id.org/ro/crate") in s.profiles)
+        self.assertIsNone(s.context, "Unexpected context")
+
     def testRepr(self):
         s = Signpost(
             LinkRel.cite_as,

--- a/tests/test_signpost.py
+++ b/tests/test_signpost.py
@@ -353,9 +353,8 @@ class TestSignpost(unittest.TestCase):
         self.assertTrue(AbsoluteURI(
             "http://www.w3.org/ns/json-ld#compacted") in s.profiles)
         self.assertTrue(AbsoluteURI(
-            "http://www.w3.org/ns/json-ld#compacted") in s.profiles)
-        self.assertTrue(AbsoluteURI(
             "https://w3id.org/ro/crate") in s.profiles)
+        self.assertEqual(3, len(s.profiles))
         self.assertIsNone(s.context, "Unexpected context")
 
     def testRepr(self):


### PR DESCRIPTION
..for instance http://www.w3.org/ns/json-ld#flattened on `application/ld+json`

These were mistakenly flagged as not valid URIs as the wrong pattern was used for validation.